### PR TITLE
Add Entries function

### DIFF
--- a/map.go
+++ b/map.go
@@ -1,0 +1,26 @@
+package gog
+
+// KV represents a key-value pair.
+type KV[K comparable, V any] struct {
+	// Key holds the key of this key-value pair.
+	Key K
+
+	// Value holds the value of this key-value pair.
+	Value V
+}
+
+// Entries returns a slice of key-value pair mappings that make up
+// the specified map.
+//
+// Note: There is no guarantee as to the order of the returned entries, nor
+// is that order guaranteed to be consistent across two calls.
+func Entries[K comparable, V any](m map[K]V) []KV[K, V] {
+	result := make([]KV[K, V], 0, len(m))
+	for k, v := range m {
+		result = append(result, KV[K, V]{
+			Key:   k,
+			Value: v,
+		})
+	}
+	return result
+}

--- a/map_test.go
+++ b/map_test.go
@@ -1,0 +1,36 @@
+package gog_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/mokiat/gog"
+)
+
+var _ = Describe("Map", func() {
+
+	Describe("Entries", func() {
+		It("returns the map entries", func() {
+			result := gog.Entries(map[string]int{
+				"one":   1,
+				"two":   2,
+				"three": 3,
+			})
+			Expect(result).To(ConsistOf(
+				gog.KV[string, int]{
+					Key:   "one",
+					Value: 1,
+				},
+				gog.KV[string, int]{
+					Key:   "two",
+					Value: 2,
+				},
+				gog.KV[string, int]{
+					Key:   "three",
+					Value: 3,
+				},
+			))
+		})
+	})
+
+})


### PR DESCRIPTION
Adds an `Entries` function that returns all key-value pairs of a Go map.
