### PR TITLE
Add additional slice functions

### DIFF
--- a/slice.go
+++ b/slice.go
@@ -62,3 +62,13 @@ func Dedupe[T comparable](slice []T) []T {
 	}
 	return result
 }
+
+// Flatten returns a new slice that is the result of merging all nested
+// slices into a single top-level slice.
+func Flatten[T any](slice [][]T) []T {
+	var result []T
+	for _, subSlice := range slice {
+		result = append(result, subSlice...)
+	}
+	return result
+}

--- a/slice.go
+++ b/slice.go
@@ -47,7 +47,7 @@ func Partition[S any, K comparable](slice []S, fn func(S) K) map[K][]S {
 }
 
 // Mapping is similar to Partition, except that it allows one to transform
-// the values stored in the patition buckets.
+// the values stored in the partition buckets.
 // In essence, it allows the caller to construct an almost arbitrary map
 // (it is always of kind map[key][]value, though the types of the keys and the
 // values are user controlled) from an arbitrary slice.

--- a/slice.go
+++ b/slice.go
@@ -46,6 +46,20 @@ func Partition[S any, K comparable](slice []S, fn func(S) K) map[K][]S {
 	return result
 }
 
+// Mapping is similar to Partition, except that it allows one to transform
+// the values stored in the patition buckets.
+// In essence, it allows the caller to construct an almost arbitrary map
+// (it is always of kind map[key][]value, though the types of the keys and the
+// values are user controlled) from an arbitrary slice.
+func Mapping[S any, K comparable, V any](slice []S, fn func(S) (K, V)) map[K][]V {
+	result := make(map[K][]V)
+	for _, v := range slice {
+		key, value := fn(v)
+		result[key] = append(result[key], value)
+	}
+	return result
+}
+
 // Dedupe returns a new slice that contains only distinct elements from
 // the original slice.
 func Dedupe[T comparable](slice []T) []T {

--- a/slice_test.go
+++ b/slice_test.go
@@ -86,4 +86,21 @@ var _ = Describe("Slice", func() {
 		})
 	})
 
+	Describe("Flatten", func() {
+		It("returns a flat slice", func() {
+			source := [][]int{
+				{1, 2, 5, 8, 8},
+				{1, 11},
+			}
+			target := gog.Flatten(source)
+			Expect(target).To(Equal([]int{
+				1, 2, 5, 8, 8, 1, 11,
+			}))
+		})
+
+		It("preserves the nil slice", func() {
+			Expect(gog.Flatten[int](nil)).To(Equal([]int(nil)))
+		})
+	})
+
 })

--- a/slice_test.go
+++ b/slice_test.go
@@ -72,6 +72,23 @@ var _ = Describe("Slice", func() {
 		})
 	})
 
+	Describe("Mapping", func() {
+		It("partitions a slice into custom buckets", func() {
+			source := []int{0, 1, 2, 3, 4, 5, 6}
+			target := gog.Mapping(source, func(v int) (string, string) {
+				if v%2 == 0 {
+					return "even", strconv.Itoa(v)
+				} else {
+					return "odd", strconv.Itoa(v)
+				}
+			})
+			Expect(target).To(Equal(map[string][]string{
+				"even": {"0", "2", "4", "6"},
+				"odd":  {"1", "3", "5"},
+			}))
+		})
+	})
+
 	Describe("Dedupe", func() {
 		It("returns a slice of distinct elements", func() {
 			source := []int{0, 0, 2, 3, 3, 5, 6, 6}


### PR DESCRIPTION
Adds the following functions:

- `Flatten` - converts a slice of slices into a single-level slice
- `Mapping` - similar to Partition, except that it allows one to specify the bucket values as well
