### PR TITLE
Code, API and Docu improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,17 @@
 # GoG (Go Generics)
 
+[![Go Reference](https://pkg.go.dev/badge/github.com/mokiat/gog.svg)](https://pkg.go.dev/github.com/mokiat/gog)
+[![Go Report Card](https://goreportcard.com/badge/github.com/mokiat/gog)](https://goreportcard.com/report/github.com/mokiat/gog)
+
 GoG is a Go library with useful generic functions and types.
 
 Since the introduction of generics in Go 1.18, a number of useful and reusable
 data structures, algorithms and utility functions are now possible. This library
 attempts to cover some of the most common use cases.
 
-It does not include functions that are already provided by
-[x/exp/slices](https://pkg.go.dev/golang.org/x/exp/slices) and
-[x/exp/maps](https://pkg.go.dev/golang.org/x/exp/maps), both of which might
-soon be part of the built-in packages.
+It avoids duplicating functions that are already provided by
+[slices](https://pkg.go.dev/slices) and
+[maps](https://pkg.go.dev/maps).
 
 For a complete list on available functions and types, check the
 godoc documentation for this project:

--- a/slice.go
+++ b/slice.go
@@ -15,6 +15,19 @@ func Map[S, T any](slice []S, fn func(S) T) []T {
 	return result
 }
 
+// MapIndex is similar to Map, except that it passes the element index
+// to the closure function as well.
+func MapIndex[S, T any](slice []S, fn func(int, S) T) []T {
+	if slice == nil {
+		return nil
+	}
+	result := make([]T, len(slice))
+	for i, v := range slice {
+		result[i] = fn(i, v)
+	}
+	return result
+}
+
 // Reduce compacts a slice into a single value. The provided function is used
 // to perform the reduction starting with the initialValue.
 func Reduce[S, T any](slice []S, initialValue T, fn func(accum T, value S) T) T {
@@ -95,6 +108,14 @@ func Flatten[T any](slice [][]T) []T {
 func Mutate[T any](slice []T, fn func(e *T)) {
 	for i := range slice {
 		fn(&slice[i])
+	}
+}
+
+// MutateIndex is similar to Mutate, except that it passes the element index
+// to the closure function as well.
+func MutateIndex[T any](slice []T, fn func(index int, e *T)) {
+	for i := range slice {
+		fn(i, &slice[i])
 	}
 }
 

--- a/slice.go
+++ b/slice.go
@@ -150,6 +150,8 @@ func DerefElements[T any](slice []*T) []T {
 //
 // This function always allocates a brand new slice with appropriate
 // capacity and never mutates any of the passed slices.
+//
+// Deprecated: Use built-in slices.Concat instead.
 func Concat[T any](slices ...[]T) []T {
 	capacity := 0
 	for _, slice := range slices {

--- a/slice.go
+++ b/slice.go
@@ -1,6 +1,10 @@
 package gog
 
-import "golang.org/x/exp/maps"
+import (
+	"slices"
+
+	"golang.org/x/exp/maps"
+)
 
 // Map can be used to transform one slice into another by providing a
 // function to do the mapping.
@@ -150,17 +154,10 @@ func DerefElements[T any](slice []*T) []T {
 //
 // This function always allocates a brand new slice with appropriate
 // capacity and never mutates any of the passed slices.
-func Concat[T any](slices ...[]T) []T {
-	capacity := 0
-	for _, slice := range slices {
-		capacity += len(slice)
-	}
-
-	result := make([]T, 0, capacity)
-	for _, slice := range slices {
-		result = append(result, slice...)
-	}
-	return result
+//
+// Deprecated: Use slices.Concat instead.
+func Concat[T any](subSlices ...[]T) []T {
+	return slices.Concat(subSlices...)
 }
 
 // Merge takes a series of maps and merges them into a single map.

--- a/slice.go
+++ b/slice.go
@@ -1,10 +1,6 @@
 package gog
 
-import (
-	"slices"
-
-	"golang.org/x/exp/maps"
-)
+import "golang.org/x/exp/maps"
 
 // Map can be used to transform one slice into another by providing a
 // function to do the mapping.
@@ -154,10 +150,17 @@ func DerefElements[T any](slice []*T) []T {
 //
 // This function always allocates a brand new slice with appropriate
 // capacity and never mutates any of the passed slices.
-//
-// Deprecated: Use slices.Concat instead.
-func Concat[T any](subSlices ...[]T) []T {
-	return slices.Concat(subSlices...)
+func Concat[T any](slices ...[]T) []T {
+	capacity := 0
+	for _, slice := range slices {
+		capacity += len(slice)
+	}
+
+	result := make([]T, 0, capacity)
+	for _, slice := range slices {
+		result = append(result, slice...)
+	}
+	return result
 }
 
 // Merge takes a series of maps and merges them into a single map.

--- a/slice_test.go
+++ b/slice_test.go
@@ -29,6 +29,24 @@ var _ = Describe("Slice", func() {
 		})
 	})
 
+	Describe("MapIndex", func() {
+		mapFunc := func(index, v int) string {
+			return strconv.Itoa(v * index)
+		}
+
+		It("converts from one slice type to another", func() {
+			source := []int{1, 2, 3}
+			target := gog.MapIndex(source, mapFunc)
+			Expect(target).To(Equal([]string{
+				"0", "2", "6",
+			}))
+		})
+
+		It("preserves the nil slice", func() {
+			Expect(gog.MapIndex(nil, mapFunc)).To(Equal([]string(nil)))
+		})
+	})
+
 	Describe("Reduce", func() {
 		It("reduces a slice to a single value", func() {
 			source := []int{1, 2, 3}
@@ -140,6 +158,30 @@ var _ = Describe("Slice", func() {
 		It("ignores nil slices", func() {
 			var slice []int
 			gog.Mutate(slice, double)
+			Expect(slice).To(Equal([]int(nil)))
+		})
+	})
+
+	Describe("MutateIndex", func() {
+		timesIndex := func(index int, v *int) {
+			*v *= index
+		}
+
+		It("mutates the items of a slice", func() {
+			slice := []int{1, 2, 3, 4}
+			gog.MutateIndex(slice, timesIndex)
+			Expect(slice).To(Equal([]int{0, 2, 6, 12}))
+		})
+
+		It("ignores empty slices", func() {
+			slice := []int{}
+			gog.MutateIndex(slice, timesIndex)
+			Expect(slice).To(Equal([]int{}))
+		})
+
+		It("ignores nil slices", func() {
+			var slice []int
+			gog.MutateIndex(slice, timesIndex)
 			Expect(slice).To(Equal([]int(nil)))
 		})
 	})

--- a/value.go
+++ b/value.go
@@ -1,0 +1,7 @@
+package gog
+
+// Zero returns the zero value of the generic type T.
+func Zero[T any]() T {
+	var zero T
+	return zero
+}

--- a/value_test.go
+++ b/value_test.go
@@ -1,0 +1,22 @@
+package gog_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/mokiat/gog"
+)
+
+var _ = Describe("Value", func() {
+
+	Describe("Zero", func() {
+
+		It("returns the zero value", func() {
+			Expect(gog.Zero[int]()).To(Equal(0))
+			Expect(gog.Zero[string]()).To(Equal(""))
+			Expect(gog.Zero[bool]()).To(Equal(false))
+		})
+
+	})
+
+})


### PR DESCRIPTION
## Changes

- Updates the README
- Adds `MapIndex` and `MutateIndex` function variants
- Deprecates the `Concat` function in favour of `slices.Concat`
  - It does not change the implementation to use `slices.Concat` in order to preserve backward compatibility, since the two behave slightly differently.
- Adds a `Zero` function
