### PR TITLE
Add helper functions to seq and filter packages

### DIFF
--- a/ds/doc.go
+++ b/ds/doc.go
@@ -1,7 +1,7 @@
 // Package ds provides various data structure implementations with generics.
 //
 // Prior to Go 1.18, such data structures could not be implemented in a
-// satisfactory way, as one had to use interfaces, which ofter resulted in
+// satisfactory way, as one had to use interfaces, which often resulted in
 // unreadable code, memory allocations and conditions for unexpected panics.
 //
 // Now that Go has generics, this package provides some common data structures

--- a/ds/pool.go
+++ b/ds/pool.go
@@ -7,7 +7,7 @@ func NewPool[T any]() *Pool[T] {
 	}
 }
 
-// Pool represents a storage structure that can preseve allocated objects
+// Pool represents a storage structure that can preserve allocated objects
 // for faster reuse.
 type Pool[T any] struct {
 	items *Stack[*T]

--- a/ds/set.go
+++ b/ds/set.go
@@ -98,7 +98,7 @@ func (s *Set[T]) Size() int {
 
 // Add adds the specified item to this Set if it was not present already.
 // This method returns true if the operation was performed and false if
-// the item was aleady present.
+// the item was already present.
 func (s *Set[T]) Add(item T) bool {
 	if s.Contains(item) {
 		return false

--- a/filter/func.go
+++ b/filter/func.go
@@ -1,5 +1,7 @@
 package filter
 
+import "slices"
+
 // Func represents a filtering function. The actual semantics of the Func
 // depend on the user but in general if true is returned then the value
 // that is being checked is accepted.
@@ -34,6 +36,14 @@ func Not[T any](delegate Func[T]) Func[T] {
 func Equal[T comparable](expected T) Func[T] {
 	return func(item T) bool {
 		return item == expected
+	}
+}
+
+// OneOf returns a filter that returns true only if the input value matches
+// one of the specified values.
+func OneOf[T comparable](expected ...T) Func[T] {
+	return func(item T) bool {
+		return slices.Contains(expected, item)
 	}
 }
 

--- a/filter/func_test.go
+++ b/filter/func_test.go
@@ -42,6 +42,18 @@ var _ = Describe("Func", func() {
 		})
 	})
 
+	Describe("OneOf", func() {
+		It("returns true on matching value", func() {
+			fltr := filter.OneOf("a", "b", "c")
+			Expect(fltr("b")).To(BeTrue())
+		})
+
+		It("returns false on non-matching value", func() {
+			fltr := filter.OneOf("a", "b", "c")
+			Expect(fltr("z")).To(BeFalse())
+		})
+	})
+
 	Describe("Or", func() {
 		It("returns true if the input value matches one of the conditions", func() {
 			fltr := filter.Or(filter.Equal("a"), filter.Equal("b"))

--- a/pointer.go
+++ b/pointer.go
@@ -5,7 +5,7 @@ func PtrOf[T any](v T) *T {
 	return &v
 }
 
-// ValueOf is the opposite of PtrOf. It takes a pointer an dereferences it.
+// ValueOf is the opposite of PtrOf. It takes a pointer and dereferences it.
 // If the pointer is nil, then it uses the provided defaultValue.
 func ValueOf[T any](v *T, defaultValue T) T {
 	if v == nil {

--- a/seq/transform.go
+++ b/seq/transform.go
@@ -20,7 +20,7 @@ func Map[T any, S any](src iter.Seq[S], fn func(S) T) iter.Seq[T] {
 
 // BatchSlice groups the elements of the source sequence into batches with the
 // same key, as determined by the key function. In order for this function to
-// work best, it is assumed that items are already sorted acoording to the key
+// work best, it is assumed that items are already sorted according to the key
 // function.
 //
 // The maxSize parameter can be used to limit the size of the batches. If the
@@ -72,7 +72,7 @@ func BatchSliceFast[T any](items []T, eqFunc func(items []T, i, j int) bool, max
 
 // Reduce compacts a sequence into a single value. The provided function is used
 // to perform the reduction starting with the initialValue.
-func Reduce[T any, S any](src iter.Seq[S], initialValue T, fn func(accum T, valye S) T) T {
+func Reduce[T any, S any](src iter.Seq[S], initialValue T, fn func(accum T, value S) T) T {
 	accum := initialValue
 	for v := range src {
 		accum = fn(accum, v)

--- a/seq/transform.go
+++ b/seq/transform.go
@@ -92,3 +92,17 @@ func Sum[T constr.Numeric](src iter.Seq[T]) T {
 	}
 	return result
 }
+
+// Indexed returns a new key-value pair iterator from a value iterator, where
+// it assigns indices as keys to each value.
+func Indexed[T any](src iter.Seq[T]) iter.Seq2[int, T] {
+	return func(yield func(int, T) bool) {
+		index := 0
+		for item := range src {
+			if !yield(index, item) {
+				return
+			}
+			index++
+		}
+	}
+}

--- a/seq/transform_test.go
+++ b/seq/transform_test.go
@@ -1,6 +1,7 @@
 package seq_test
 
 import (
+	"maps"
 	"slices"
 	"strconv"
 
@@ -112,6 +113,19 @@ var _ = Describe("Transform", func() {
 			source := slices.Values([]int{})
 			result := seq.Sum(source)
 			Expect(result).To(Equal(0))
+		})
+	})
+
+	Describe("Indexed", func() {
+		It("assigns indices to the sequence", func() {
+			source := slices.Values([]string{"a", "b", "c"})
+			result := seq.Indexed(source)
+			items := maps.Collect(result)
+			Expect(items).To(Equal(map[int]string{
+				0: "a",
+				1: "b",
+				2: "c",
+			}))
 		})
 	})
 })


### PR DESCRIPTION
## Changes

- Adds a `OneOf` predicate function to `filter` package
- Adds a `Indexed` transform function to `seq` package
- Fixes spelling errors
