### PR TITLE
Deprecation and fixes of old or misleading API functions

### DIFF
--- a/ds/example_test.go
+++ b/ds/example_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func ExampleHeap() {
-	heap := ds.NewHeap(0, func(a, b int) bool {
+	heap := ds.EmptyHeap(func(a, b int) bool {
 		return a < b
 	})
 	heap.Push(100)
@@ -32,7 +32,7 @@ func ExampleHeap() {
 }
 
 func ExampleList() {
-	list := ds.NewList[string](0)
+	list := ds.EmptyList[string]()
 	list.Add("first")
 	list.Add("second")
 	list.Add("third")
@@ -46,7 +46,7 @@ func ExampleList() {
 }
 
 func ExamplePool() {
-	pool := ds.NewPool[bytes.Buffer]()
+	pool := ds.EmptyPool[bytes.Buffer]()
 
 	buffer := pool.Fetch()
 	buffer.Reset()
@@ -62,7 +62,7 @@ func ExamplePool() {
 }
 
 func ExampleSet() {
-	set := ds.NewSet[int](0)
+	set := ds.EmptySet[int]()
 	set.Add(2)
 	set.Add(3)
 	set.Add(5)
@@ -80,7 +80,7 @@ func ExampleSet() {
 }
 
 func ExampleStack() {
-	stack := ds.NewStack[string](3)
+	stack := ds.EmptyStack[string]()
 	stack.Push("first")
 	stack.Push("second")
 	stack.Push("third")

--- a/ds/heap.go
+++ b/ds/heap.go
@@ -2,15 +2,36 @@ package ds
 
 import "slices"
 
-// NewHeap creates a new Heap instance that is configured to use the
+// EmptyHeap creates a new empty Heap that is configured to use the specified
+// better function to order items. When better returns true, the first argument
+// will be placed higher in the heap.
+func EmptyHeap[T any](better func(a, b T) bool) *Heap[T] {
+	return PreallocatedHeap(0, better)
+}
+
+// PreallocatedHeap creates a new Heap instance that is configured to use the
 // specified better function to order items. When better returns true, the
 // first argument will be placed higher in the heap.
-// The specified initialCapacity is used to preallocate memory.
-func NewHeap[T any](initialCapacity int, better func(a, b T) bool) *Heap[T] {
+//
+// The specified initialCapacity is only used to preallocate memory and does
+// not act as an upper bound.
+func PreallocatedHeap[T any](initialCapacity int, better func(a, b T) bool) *Heap[T] {
 	return &Heap[T]{
 		better: better,
 		items:  make([]T, 0, initialCapacity),
 	}
+}
+
+// NewHeap creates a new Heap instance that is configured to use the
+// specified better function to order items. When better returns true, the
+// first argument will be placed higher in the heap.
+// The specified initialCapacity is used to preallocate memory.
+//
+// Deprecated: Use EmptyHeap or PreallocatedHeap instead.
+//
+//go:fix inline
+func NewHeap[T any](initialCapacity int, better func(a, b T) bool) *Heap[T] {
+	return PreallocatedHeap(initialCapacity, better)
 }
 
 // Heap is a data structure that orders items when inserted according to a

--- a/ds/heap.go
+++ b/ds/heap.go
@@ -85,8 +85,8 @@ func (h *Heap[T]) Clear() {
 }
 
 // Clip removes unused capacity from the Heap.
-func (s *Heap[T]) Clip() {
-	s.items = slices.Clip(s.items)
+func (h *Heap[T]) Clip() {
+	h.items = slices.Clip(h.items)
 }
 
 func (h *Heap[T]) siftUp(value T, index int) {

--- a/ds/heap_test.go
+++ b/ds/heap_test.go
@@ -14,7 +14,7 @@ var _ = Describe("Heap", func() {
 		smallerInt := func(a, b int) bool {
 			return a < b
 		}
-		heap = ds.NewHeap(0, smallerInt)
+		heap = ds.EmptyHeap(smallerInt)
 	})
 
 	It("is empty by default", func() {

--- a/ds/list.go
+++ b/ds/list.go
@@ -2,13 +2,28 @@ package ds
 
 import "slices"
 
-// NewList creates a new List with the given capacity. The capacity can be
-// used as a form of optimization. Regardless of the value, the initial size
-// of the list is zero and the list can grow past the specified capacity.
-func NewList[T comparable](initialCapacity int) *List[T] {
+// EmptyList creates a new empty List.
+func EmptyList[T comparable]() *List[T] {
+	return PreallocatedList[T](0)
+}
+
+// PreallocatedList creates a new List with the specified initial capacity,
+// which is only used to preallocate memory and does not act as an upper bound.
+func PreallocatedList[T comparable](initialCapacity int) *List[T] {
 	return &List[T]{
 		items: make([]T, 0, initialCapacity),
 	}
+}
+
+// NewList creates a new List with the given capacity. The capacity can be
+// used as a form of optimization. Regardless of the value, the initial size
+// of the list is zero and the list can grow past the specified capacity.
+//
+// Deprecated: Use EmptyList or PreallocatedList instead.
+//
+//go:fix inline
+func NewList[T comparable](initialCapacity int) *List[T] {
+	return PreallocatedList[T](initialCapacity)
 }
 
 // ListFromSlice constructs a new List that is based on the items from the

--- a/ds/list_test.go
+++ b/ds/list_test.go
@@ -13,7 +13,7 @@ var _ = Describe("List", func() {
 	)
 
 	BeforeEach(func() {
-		list = ds.NewList[string](0)
+		list = ds.EmptyList[string]()
 	})
 
 	It("is empty by default", func() {
@@ -29,7 +29,7 @@ var _ = Describe("List", func() {
 	})
 
 	It("equals an empty list", func() {
-		other := ds.NewList[string](0)
+		other := ds.EmptyList[string]()
 		Expect(list.Equals(other)).To(BeTrue())
 	})
 

--- a/ds/pool.go
+++ b/ds/pool.go
@@ -1,10 +1,29 @@
 package ds
 
-// NewPool creates a new Pool instance.
-func NewPool[T any]() *Pool[T] {
-	return &Pool[T]{
-		items: NewStack[*T](0),
+// EmptyPool creates a new Pool instance.
+func EmptyPool[T any]() *Pool[T] {
+	return PreallocatedPool[T](0)
+}
+
+// PreallocatedPool creates a new Pool instance with a preallocated capacity,
+// which is only used to preallocate memory and does not act as an upper bound.
+func PreallocatedPool[T any](initialCapacity int) *Pool[T] {
+	pool := &Pool[T]{
+		items: PreallocatedStack[*T](initialCapacity),
 	}
+	for range initialCapacity {
+		pool.items.Push(new(T))
+	}
+	return pool
+}
+
+// NewPool creates a new Pool instance.
+//
+// Deprecated: Use EmptyPool or PreallocatedPool instead.
+//
+//go:fix inline
+func NewPool[T any]() *Pool[T] {
+	return EmptyPool[T]()
 }
 
 // Pool represents a storage structure that can preserve allocated objects

--- a/ds/pool_test.go
+++ b/ds/pool_test.go
@@ -15,7 +15,7 @@ var _ = Describe("Pool", func() {
 	var pool *ds.Pool[Item]
 
 	BeforeEach(func() {
-		pool = ds.NewPool[Item]()
+		pool = ds.EmptyPool[Item]()
 	})
 
 	It("is initially empty", func() {

--- a/ds/set.go
+++ b/ds/set.go
@@ -2,18 +2,34 @@ package ds
 
 import "maps"
 
-// NewSet creates a new Set instance with the specified initial capacity,
-// which is only used to preallocate memory and does not act as an upper bound.
-func NewSet[T comparable](initialCapacity int) *Set[T] {
+// EmptySet creates a new empty Set instance.
+func EmptySet[T comparable]() *Set[T] {
+	return PreallocatedSet[T](0)
+}
+
+// PreallocatedSet creates a new Set instance with the specified initial
+// capacity, which is only used to preallocate memory and does not act as
+// an upper bound.
+func PreallocatedSet[T comparable](initialCapacity int) *Set[T] {
 	return &Set[T]{
 		items: make(map[T]struct{}, initialCapacity),
 	}
 }
 
+// NewSet creates a new Set instance with the specified initial capacity,
+// which is only used to preallocate memory and does not act as an upper bound.
+//
+// Deprecated: Use EmptySet or PreallocatedSet instead.
+//
+//go:fix inline
+func NewSet[T comparable](initialCapacity int) *Set[T] {
+	return PreallocatedSet[T](initialCapacity)
+}
+
 // SetFromSlice creates a new Set instance based on the elements contained
 // in the provided slice.
 func SetFromSlice[T comparable](slice []T) *Set[T] {
-	result := NewSet[T](len(slice))
+	result := PreallocatedSet[T](len(slice))
 	for _, item := range slice {
 		result.items[item] = struct{}{}
 	}
@@ -23,7 +39,7 @@ func SetFromSlice[T comparable](slice []T) *Set[T] {
 // SetFromMapKeys creates a new Set instance based on the keys of the
 // provided map.
 func SetFromMapKeys[T comparable, V any](m map[T]V) *Set[T] {
-	result := NewSet[T](len(m))
+	result := PreallocatedSet[T](len(m))
 	for key := range m {
 		result.items[key] = struct{}{}
 	}
@@ -33,7 +49,7 @@ func SetFromMapKeys[T comparable, V any](m map[T]V) *Set[T] {
 // SetFromMapValues creates a new Set instance based on the values of the
 // provided map.
 func SetFromMapValues[K comparable, V comparable](m map[K]V) *Set[V] {
-	result := NewSet[V](len(m))
+	result := PreallocatedSet[V](len(m))
 	for _, value := range m {
 		result.items[value] = struct{}{}
 	}
@@ -42,7 +58,7 @@ func SetFromMapValues[K comparable, V comparable](m map[K]V) *Set[V] {
 
 // SetUnion creates a new Set that is the union of the specified sets.
 func SetUnion[T comparable](first, second *Set[T]) *Set[T] {
-	result := NewSet[T](first.Size() + second.Size())
+	result := PreallocatedSet[T](first.Size() + second.Size())
 	for item := range first.items {
 		result.items[item] = struct{}{}
 	}
@@ -55,7 +71,7 @@ func SetUnion[T comparable](first, second *Set[T]) *Set[T] {
 // SetDifference creates a new Set that holds the difference between the
 // first and the second specified sets.
 func SetDifference[T comparable](first, second *Set[T]) *Set[T] {
-	result := NewSet[T](first.Size())
+	result := PreallocatedSet[T](first.Size())
 	for item := range first.items {
 		if _, ok := second.items[item]; !ok {
 			result.items[item] = struct{}{}
@@ -67,7 +83,7 @@ func SetDifference[T comparable](first, second *Set[T]) *Set[T] {
 // SetIntersection creates a new Set that holds the intersection of the
 // items of the two specified sets.
 func SetIntersection[T comparable](first, second *Set[T]) *Set[T] {
-	result := NewSet[T](0)
+	result := PreallocatedSet[T](0)
 	for item := range first.items {
 		if _, ok := second.items[item]; ok {
 			result.items[item] = struct{}{}
@@ -188,9 +204,7 @@ func (s *Set[T]) Equals(other *Set[T]) bool {
 
 // Clear removes all items from this Set.
 func (s *Set[T]) Clear() {
-	for v := range s.items {
-		delete(s.items, v)
-	}
+	clear(s.items)
 }
 
 // Clip removes unused capacity from the Set.

--- a/ds/set_test.go
+++ b/ds/set_test.go
@@ -13,7 +13,7 @@ var _ = Describe("Set", func() {
 	)
 
 	BeforeEach(func() {
-		set = ds.NewSet[string](0)
+		set = ds.EmptySet[string]()
 	})
 
 	It("is empty by default", func() {
@@ -29,7 +29,7 @@ var _ = Describe("Set", func() {
 	})
 
 	It("equals an empty set", func() {
-		other := ds.NewSet[string](0)
+		other := ds.EmptySet[string]()
 		Expect(set.Equals(other)).To(BeTrue())
 	})
 
@@ -73,12 +73,12 @@ var _ = Describe("Set", func() {
 		})
 
 		It("is possible to check if a whole different set is contained", func() {
-			subSet := ds.NewSet[string](2)
+			subSet := ds.PreallocatedSet[string](2)
 			subSet.Add("first")
 			subSet.Add("third")
 			Expect(set.ContainsSet(subSet)).To(BeTrue())
 
-			mismatchSet := ds.NewSet[string](3)
+			mismatchSet := ds.PreallocatedSet[string](3)
 			mismatchSet.Add("first")
 			mismatchSet.Add("third")
 			mismatchSet.Add("fifth")
@@ -153,7 +153,7 @@ var _ = Describe("Set", func() {
 
 		When("another set is added", func() {
 			BeforeEach(func() {
-				other := ds.NewSet[string](3)
+				other := ds.PreallocatedSet[string](5)
 				other.Add("second")
 				other.Add("third")
 				other.Add("fourth")
@@ -174,7 +174,7 @@ var _ = Describe("Set", func() {
 			})
 
 			It("returns false if the set is already contained", func() {
-				other := ds.NewSet[string](2)
+				other := ds.PreallocatedSet[string](2)
 				other.Add("second")
 				other.Add("third")
 				Expect(set.AddSet(other)).To(BeFalse())
@@ -183,7 +183,7 @@ var _ = Describe("Set", func() {
 
 		When("another set is removed", func() {
 			BeforeEach(func() {
-				other := ds.NewSet[string](2)
+				other := ds.PreallocatedSet[string](3)
 				other.Add("second")
 				other.Add("third")
 				other.Add("fourth")
@@ -199,7 +199,7 @@ var _ = Describe("Set", func() {
 			})
 
 			It("returns false if the set is not contained", func() {
-				other := ds.NewSet[string](2)
+				other := ds.PreallocatedSet[string](2)
 				other.Add("fourth")
 				other.Add("fifth")
 				Expect(set.RemoveSet(other)).To(BeFalse())
@@ -310,11 +310,11 @@ var _ = Describe("Set", func() {
 		)
 
 		BeforeEach(func() {
-			firstSet = ds.NewSet[string](2)
+			firstSet = ds.PreallocatedSet[string](2)
 			firstSet.Add("a")
 			firstSet.Add("b")
 
-			secondSet = ds.NewSet[string](2)
+			secondSet = ds.PreallocatedSet[string](2)
 			secondSet.Add("b")
 			secondSet.Add("c")
 
@@ -339,11 +339,11 @@ var _ = Describe("Set", func() {
 		)
 
 		BeforeEach(func() {
-			firstSet = ds.NewSet[string](2)
+			firstSet = ds.PreallocatedSet[string](2)
 			firstSet.Add("a")
 			firstSet.Add("b")
 
-			secondSet = ds.NewSet[string](2)
+			secondSet = ds.PreallocatedSet[string](2)
 			secondSet.Add("b")
 			secondSet.Add("c")
 
@@ -366,12 +366,12 @@ var _ = Describe("Set", func() {
 		)
 
 		BeforeEach(func() {
-			firstSet = ds.NewSet[string](3)
+			firstSet = ds.PreallocatedSet[string](3)
 			firstSet.Add("a")
 			firstSet.Add("b")
 			firstSet.Add("c")
 
-			secondSet = ds.NewSet[string](3)
+			secondSet = ds.PreallocatedSet[string](3)
 			secondSet.Add("b")
 			secondSet.Add("c")
 			secondSet.Add("d")

--- a/ds/stack.go
+++ b/ds/stack.go
@@ -2,13 +2,29 @@ package ds
 
 import "slices"
 
+// EmptyStack creates an empty Stack instance.
+func EmptyStack[T any]() *Stack[T] {
+	return PreallocatedStack[T](0)
+}
+
+// PreallocatedStack creates a new Stack instance with the specified initial
+// capacity, which is only used to preallocate memory and does not act as
+// an upper bound.
+func PreallocatedStack[T any](initialCapacity int) *Stack[T] {
+	return &Stack[T]{
+		items: make([]T, 0, initialCapacity),
+	}
+}
+
 // NewStack creates a new Stack instance with the specified initial capacity,
 // which only serves to preallocate memory. Exceeding the initial capacity is
 // allowed.
-func NewStack[T any](initCapacity int) *Stack[T] {
-	return &Stack[T]{
-		items: make([]T, 0, initCapacity),
-	}
+//
+// Deprecated: Use EmptyStack or PreallocatedStack instead.
+//
+//go:fix inline
+func NewStack[T any](initialCapacity int) *Stack[T] {
+	return PreallocatedStack[T](initialCapacity)
 }
 
 // Stack is an implementation of a stack data structure. The last inserted

--- a/ds/stack_test.go
+++ b/ds/stack_test.go
@@ -13,7 +13,7 @@ var _ = Describe("Stack", func() {
 	)
 
 	BeforeEach(func() {
-		stack = ds.NewStack[string](0)
+		stack = ds.EmptyStack[string]()
 	})
 
 	It("is empty by default", func() {

--- a/filter/func.go
+++ b/filter/func.go
@@ -48,12 +48,8 @@ func OneOf[T comparable](expected ...T) Func[T] {
 }
 
 // Or returns true if any of the specified Func filters in the arguments
-// return true. If no filters are specified as arguments, then the
-// returned Func always returns true.
+// return true.
 func Or[T any](filters ...Func[T]) Func[T] {
-	if len(filters) == 0 {
-		return True[T]()
-	}
 	return func(item T) bool {
 		for _, filter := range filters {
 			if filter(item) {

--- a/filter/func_test.go
+++ b/filter/func_test.go
@@ -66,9 +66,9 @@ var _ = Describe("Func", func() {
 			Expect(fltr("c")).To(BeFalse())
 		})
 
-		It("returns true if the list of conditions is empty", func() {
+		It("returns false if the list of conditions is empty", func() {
 			fltr := filter.Or[string]()
-			Expect(fltr("irrelevant")).To(BeTrue())
+			Expect(fltr("irrelevant")).To(BeFalse())
 		})
 	})
 

--- a/pointer.go
+++ b/pointer.go
@@ -1,8 +1,13 @@
 package gog
 
 // PtrOf returns a pointer to the passed value.
+//
+// Deprecated: Use the built-in new function instead. For example,
+// instead of PtrOf(42), use new(42).
+//
+//go:fix inline
 func PtrOf[T any](v T) *T {
-	return &v
+	return new(v)
 }
 
 // ValueOf is the opposite of PtrOf. It takes a pointer and dereferences it.


### PR DESCRIPTION
## Changes

- Deprecates `gog.PtrOf`. New code should use Go's built-in `new` function.
- Introduces new `Empty<DataStruct>` and `Preallocated<DataStruct>` functions in `ds` package. The old usage of `New<DataStruct>`, which expected an integer was unintuitive and annoying when an empty one was needed. The new namings should be more descriptive. The old `New<DataStruct>` functions have been deprecated in favour of the new ones.
- **BREAKING CHANGE:** Changes the behavior of an empty `Or` filter - it now returns `false`, which is the correct behavior.
